### PR TITLE
Codenvy cloud IDE integration for setup-less easy tryout

### DIFF
--- a/.codenvy.json
+++ b/.codenvy.json
@@ -1,0 +1,138 @@
+{
+  "v": "4.0",
+  "name": "cordap-template",
+  "workspace":{
+   "name": "cordapp-tryout",
+   "defaultEnv": "cordapp-template",
+    "environments":[
+      {
+        "name":"cordapp-template",
+        "machineConfigs":[
+          {
+            "limits":{
+              "ram":2000
+            },
+            "name":"ws-machine",
+            "type":"docker",
+            "source":{
+              "content":"FROM codenvy/debian_jdk8\nEXPOSE 10003-10010",
+              "type":"dockerfile"
+            },
+            "dev":true,
+            "servers":[
+            ],
+            "envVariables":{
+            },
+            "links":[
+            ]
+          }
+        ]
+      }
+    ],
+    
+    "projects": [
+      {
+        "links": [],
+        "name": "cordapp-template-M7",
+        "attributes": {
+            "contribute_to_branch": [
+            "release-M7"
+          ]
+        },
+        "path": "/cordapp-template-M7",
+        "problems": [],
+        "mixins": [
+          "pullrequest"
+        ]
+      }
+    ],
+    "commands": [
+      {
+        "commandLine": "mkdir -p /projects/cordapp-template-M7/logs; touch /projects/cordapp-template-M7/logs/controller.log; stdbuf -oL tail -f /projects/cordapp-template-M7/logs/controller.log",
+        "name": "controller",
+        "attributes": {
+          "previewUrl": "http://${server.port.10003}/web/example"
+        },
+        "type": "custom"
+      },
+      {
+        "commandLine": "mkdir -p /projects/cordapp-template-M7/logs; touch /projects/cordapp-template-M7/logs/nodea.log; stdbuf -oL tail -f /projects/cordapp-template-M7/logs/nodea.log",
+        "name": "nodeA",
+        "attributes": {
+          "previewUrl": "http://${server.port.10005}/web/example"
+        },
+        "type": "custom"
+      },
+      {
+        "commandLine": "mkdir -p /projects/cordapp-template-M7/logs; touch /projects/cordapp-template-M7/logs/nodeb.log; stdbuf -oL tail -f /projects/cordapp-template-M7/logs/nodeb.log",
+        "name": "nodeB",
+        "attributes": {
+          "previewUrl": "http://${server.port.10007}/web/example"
+        },
+        "type": "custom"
+      },
+      {
+        "commandLine": "mkdir -p /projects/cordapp-template-M7/logs; touch /projects/cordapp-template-M7/logs/nodec.log; stdbuf -oL tail -f /projects/cordapp-template-M7/logs/nodec.log",
+        "name": "nodeC",
+        "attributes": {
+          "previewUrl": "http://${server.port.10009}/web/example"
+        },
+        "type": "custom"
+      },
+      {
+        "commandLine": "mvn clean install -f ${current.project.path}",
+        "name": "build",
+        "attributes": {},
+        "type": "mvn"
+      },
+      {
+        "commandLine": "cd /projects/cordapp-template-M7; bash ./gradlew deployNodes \n cd /projects/cordapp-template-M7/kotlin/build/nodes/controller \n java -jar corda.jar &> /projects/cordapp-template-M7/logs/controller.log & \n cd /projects/cordapp-template-M7/kotlin/build/nodes/nodea; java -jar corda.jar &> /projects/cordapp-template-M7/logs/nodea.log & \n cd /projects/cordapp-template-M7/kotlin/build/nodes/nodeb \n java -jar corda.jar &> /projects/cordapp-template-M7/logs/nodeb.log & \n cd /projects/cordapp-template-M7/kotlin/build/nodes/nodec \n java -jar corda.jar &> /projects/cordapp-template-M7/logs/nodec.log & \n stdbuf -oL echo Nodes_Started \n wait",
+        "name": "gradle-deployNodes",
+        "attributes": {
+          "previewUrl": ""
+        },
+        "type": "custom"
+      }
+    ],
+    "links": [
+     ]
+  },
+  "ide": {
+    "onProjectsLoaded": {
+      "actions": [
+        {
+          "properties": {
+            "name": "controller"
+          },
+          "id": "runCommand"
+        },
+        {
+          "properties": {
+            "name": "nodeA"
+          },
+          "id": "runCommand"
+        },
+        {
+          "properties": {
+            "name": "nodeB"
+          },
+          "id": "runCommand"
+        },
+        {
+          "properties": {
+            "name": "nodeC"
+          },
+          "id": "runCommand"
+        },
+        {
+          "properties": {
+            "name": "gradle-deployNodes"
+          },
+          "id": "runCommand"
+        }
+
+      ]
+    }
+  }
+  
+}

--- a/kotlin/src/main/resources/exampleWeb/js/angular-module.js
+++ b/kotlin/src/main/resources/exampleWeb/js/angular-module.js
@@ -28,7 +28,9 @@ app.controller('DemoAppController', function($http, $location, $uibModal) {
 
     // We identify the node based on its localhost port.
     const nodePort = $location.port();
-    const apiBaseURL = "http://localhost:" + nodePort + "/api/example/";
+    //const apiBaseURL = "http://localhost:" + nodePort + "/api/example/";
+    const apiBaseURL = window.location.origin + "/api/example/";
+
     let peers = [];
 
     $http.get(apiBaseURL + "me").then((response) => demoApp.thisNode = response.data.me);


### PR DESCRIPTION
Codenvy is a cloud based IDE based on Eclipse Che.  With just a click, cordapp-template code gets deployed on to a cloud based docker instance along with displaying the code on a browser based  IDE UI.
The tryout requires just a free account on cloudenvy.io

The IDe is populated based on JSON config in .cloudenvy.json
It is custom crafted to reflect the Kotlin build of cordapp, and making the nodes, A, B, C and controller up and running.

This is just a proof of concept to check the usefulness and level of interest.

To be incorporated in the codebase, the proper way of doing would be to incorporate the configuration generation as part of the build process. Most likely as part of documentation generation. [ A button with link to Cloudenvy workspace sits on README.md]

