### PR TITLE
Add UML diagram generation

### DIFF
--- a/doc/example_flow.plantuml
+++ b/doc/example_flow.plantuml
@@ -1,0 +1,23 @@
+@startuml
+participant Initiator
+participant Acceptor
+participant Notary
+title ExampleFlow 1\n(Purchase Order)
+
+autonumber
+
+note over Initiator : Generating transaction based on new purchase order
+note over Initiator : Signing transaction with our private key
+Initiator -> Acceptor : Sending proposed transaction to seller for review
+note over Acceptor : Receiving proposed transaction from buyer
+note over Acceptor : Verifying signatures and contract constraints
+note over Acceptor : Signing proposed transaction with our private key
+Acceptor -> Notary : Requesting signature by notary service
+note over Notary : Verify that timestamp
+note over Notary : Sign transaction
+Acceptor <- Notary: Receive signed transaction
+note over Acceptor : Validating response from Notary service
+note over Acceptor : Record transaction
+Initiator <- Acceptor : Broadcasting transaction to participants
+note over Initiator : Record transaction
+@enduml

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -45,6 +45,9 @@ dependencies {
         exclude group: "bouncycastle"
     }
 
+    // PlantUML: For Generation of Sequence Diagrams of the Flows
+    compile 'net.sourceforge.plantuml:plantuml:8039'
+
     // CorDapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps
 }
@@ -116,6 +119,17 @@ publishing {
             artifact javadocJar
         }
     }
+}
+
+task plantUML(type: JavaExec) {
+    classpath = files("build/jythonDeps/plantuml-8039.jar")
+    main = "net.sourceforge.plantuml.Run"
+    args = [
+            "-tsvg",
+            "-output", "../kotlin/build/doc",
+            "-exclude", "inc_*",
+            "../doc/*.plantuml"
+    ]
 }
 
 task runExampleClientRPC(type: JavaExec) {


### PR DESCRIPTION
Sometimes it is difficult to immediately understand how the flow works merely by looking at the code. 

This commit makes it possible to document this using a `plantuml` file, which can then be used to generate a UML based sequence diagram using the Gradle task `plantUML`.

This is based on the open source tool [PlantUML](http://plantuml.com/sequence-diagram).