### PR TITLE
Upgrade to latest corda gradle plugin verison

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ install step.**
 
      gradlew.bat deployNodes
 
-Note: You'll need to re-run this build step after making any changes to 
+Note: You'll need to re-run this build step after making any changes to
 the template for these to take effect on the node.
 
 ## Running the Nodes
 
-Once the build finishes, change directories to the folder where the newly 
+Once the build finishes, change directories to the folder where the newly
 built nodes are located:
 
 **Kotlin:**
 
-     cd kotlin/build/nodes
+     cd kotlin-source/build/nodes
 
 **Java:**
 
-     cd java/build/nodes
+     cd java-source/build/nodes
 
 The Gradle build script will have created a folder for each node. You'll
 see three folders, one for each node and a `runnodes` script. You can

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.corda_version = '0.9-SNAPSHOT'
-    ext.corda_gradle_plugins_version = '0.8.1'
+    ext.corda_gradle_plugins_version = '0.8.2'
     ext.kotlin_version = '1.0.6'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.corda_version = '0.9-SNAPSHOT'
-    ext.corda_gradle_plugins_version = '0.7.1'
+    ext.corda_gradle_plugins_version = '0.8.1'
     ext.kotlin_version = '1.0.6'
 
     repositories {


### PR DESCRIPTION
The node configuration attribute `extraAdvertisedServiceIds` now expects a List per https://github.com/corda/corda/commit/7181b697a3efb2df55d8540de17ce4dbf16e3f47 -- it previously expected a string.

Without using the latest corda_gradle_plugins_version, deployNodes will define `extraAdvertisedServiceIds` as strings which leads to failures on `runnodes`.